### PR TITLE
fix: fullscreen cinematic loader with perfect center layout (#1)

### DIFF
--- a/main.js
+++ b/main.js
@@ -18,6 +18,9 @@ const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)
 // 1. LOADING SCREEN (PUBG-Style Percentage Loader)
 // Premium minimal design with smooth easing
 // ──────────────────────────────────────────────────────
+// Lock page scroll immediately so no content peeks under the loader
+document.body.classList.add('loader-active');
+
 window.addEventListener('load', () => {
   const loader = document.getElementById('loader');
   const percentEl = document.getElementById('pubg-percent');
@@ -28,38 +31,31 @@ window.addEventListener('load', () => {
     const messages = [
       "Initializing system...",
       "Loading assets...",
-      "Analyzing files...",
+      "Crafting experience...",
       "Optimizing performance...",
-      "Building experience...",
+      "Building visuals...",
       "Almost ready..."
     ];
     
     let currentPercent = 0;
     let lastDisplayedPercent = -1;
     
-    // Easing functions for natural progression
+    // Smooth easing for cinematic feel
     function easeOutExpo(x) {
       return x === 1 ? 1 : 1 - Math.pow(2, -10 * x);
     }
     
-    function easeInOutCubic(x) {
-      return x < 0.5 ? 4 * x * x * x : 1 - Math.pow(-2 * x + 2, 3) / 2;
-    }
-    
     const startTime = performance.now();
-    const minDuration = 2200; // Minimum loading time for premium feel
-    const maxDuration = 3200; // Maximum loading time
+    const minDuration = 2400; // Minimum loading time for premium feel
     
     function updateLoader(currentTime) {
       const elapsed = currentTime - startTime;
-      let progress = Math.min(elapsed / minDuration, 1);
+      const progress = Math.min(elapsed / minDuration, 1);
       
-      // Use easeOutExpo for smooth acceleration through the middle
+      // EaseOutExpo: fast start, smooth finish
       const easedProgress = easeOutExpo(progress);
       
-      // Calculate percentage with smooth increment
-      currentPercent = Math.floor(easedProgress * 100);
-      currentPercent = Math.min(currentPercent, 100);
+      currentPercent = Math.min(Math.floor(easedProgress * 100), 100);
       
       // Only update DOM if percentage changed (performance optimization)
       if (currentPercent !== lastDisplayedPercent) {
@@ -67,40 +63,47 @@ window.addEventListener('load', () => {
         lastDisplayedPercent = currentPercent;
       }
       
-      // Update progress bar with linear transition
+      // Update progress bar
       progressBar.style.width = currentPercent + '%';
       
-      // Update loading message based on progress thresholds
-      if (currentPercent < 20) messageEl.textContent = messages[0];
-      else if (currentPercent < 35) messageEl.textContent = messages[1];
-      else if (currentPercent < 50) messageEl.textContent = messages[2];
-      else if (currentPercent < 70) messageEl.textContent = messages[3];
+      // Sync message with progress phase
+      if (currentPercent < 20)      messageEl.textContent = messages[0];
+      else if (currentPercent < 38) messageEl.textContent = messages[1];
+      else if (currentPercent < 55) messageEl.textContent = messages[2];
+      else if (currentPercent < 72) messageEl.textContent = messages[3];
       else if (currentPercent < 90) messageEl.textContent = messages[4];
-      else messageEl.textContent = messages[5];
+      else                          messageEl.textContent = messages[5];
       
       if (progress < 1) {
         requestAnimationFrame(updateLoader);
       } else {
-        // Pause at 100% for a moment, then fade out
+        // Hold at 100% for a dramatic pause, then cinematic fade-out
         setTimeout(() => {
           loader.classList.add('loaded');
+
+          // Unlock body scroll after transition completes (~900ms)
           setTimeout(() => {
-            // Trigger hero entrance or next animation if available
-            if(typeof triggerHeroEntrance === 'function') {
+            document.body.classList.remove('loader-active');
+
+            // Trigger hero entrance animations
+            if (typeof triggerHeroEntrance === 'function') {
               triggerHeroEntrance();
             }
-          }, 400);
-        }, 200); // Brief pause at completion for premium feel
+          }, 950);
+        }, 400); // Cinematic pause at 100% before exit
       }
     }
     
     requestAnimationFrame(updateLoader);
 
   } else if (loader) {
-    // Fallback if structure is missing
+    // Fallback if PUBG structure is missing
     setTimeout(() => {
       loader.classList.add('loaded');
-      if(typeof triggerHeroEntrance === 'function') triggerHeroEntrance();
+      setTimeout(() => {
+        document.body.classList.remove('loader-active');
+        if (typeof triggerHeroEntrance === 'function') triggerHeroEntrance();
+      }, 950);
     }, 2500);
   }
 });

--- a/style.css
+++ b/style.css
@@ -126,40 +126,74 @@ ul, ol { list-style: none; }
 }
 
 /* ─────────────────────────────────────────
-   LOADER
+   LOADER — FULLSCREEN CINEMATIC
    ───────────────────────────────────────── */
-.loader {
-  position: fixed; inset: 0; z-index: 99999;
-  background: #030407; /* Darker back for cinematic feel */
-  display: flex; align-items: center; justify-content: center;
-  transition: opacity 1s cubic-bezier(0.25, 0.46, 0.45, 0.94), visibility 1s ease;
-  will-change: opacity, visibility;
-  overflow: hidden;
-}
-.loader.loaded {
-  opacity: 0; visibility: hidden; pointer-events: none;
+
+/* Lock page scroll while loader is active */
+body.loader-active {
+  overflow: hidden !important;
 }
 
-/* PUBG Style Cinematic Loader */
+.loader {
+  /* True fullscreen fixed overlay */
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100vh;
+  z-index: 99999;
+
+  /* Perfect centering — both axes */
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+
+  /* Dark cinematic background — covers everything */
+  background: #030407;
+  overflow: hidden;
+
+  /* Smooth cinematic exit */
+  transition: opacity 0.9s cubic-bezier(0.25, 0.46, 0.45, 0.94),
+              visibility 0.9s ease,
+              transform 0.9s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  will-change: opacity, visibility, transform;
+
+  /* Prevent any element from sneaking out */
+  clip-path: inset(0);
+}
+
+/* Exit state: fade out + subtle scale for cinematic feel */
+.loader.loaded {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transform: scale(1.04);
+}
+
+/* PUBG Style Cinematic Loader — no position override, inherits fixed from .loader */
 .pubg-loader {
   background: radial-gradient(circle at 50% 50%, #0d1117 0%, #010204 100%);
-  position: relative;
 }
 
 /* Vignette effect for cinematic depth */
 .pubg-loader::before {
   content: '';
-  position: fixed; inset: 0;
-  background: radial-gradient(ellipse at center, transparent 0%, rgba(0, 0, 0, 0.6) 100%);
+  position: absolute;
+  top: 0; left: 0;
+  width: 100%; height: 100%;
+  background: radial-gradient(ellipse at center, transparent 0%, rgba(0, 0, 0, 0.65) 100%);
   pointer-events: none;
   z-index: 1;
 }
 
-/* Soft glow overlay */
+/* Soft orange glow overlay */
 .pubg-loader::after {
   content: '';
-  position: fixed; inset: 0;
-  background: radial-gradient(circle at 50% 50%, rgba(255, 107, 53, 0.03) 0%, transparent 70%);
+  position: absolute;
+  top: 0; left: 0;
+  width: 100%; height: 100%;
+  background: radial-gradient(circle at 50% 50%, rgba(255, 107, 53, 0.04) 0%, transparent 70%);
   pointer-events: none;
   z-index: 0;
   animation: softGlowPulse 3.5s ease-in-out infinite;
@@ -171,7 +205,9 @@ ul, ol { list-style: none; }
 }
 
 .loader-ambient-glow {
-  position: absolute; width: 100vw; height: 100vh;
+  position: absolute;
+  top: 0; left: 0;
+  width: 100%; height: 100%;
   background: radial-gradient(ellipse at center, rgba(0, 245, 255, 0.04) 0%, transparent 60%);
   animation: pulseAmbient 5s ease-in-out infinite;
   pointer-events: none;
@@ -206,23 +242,34 @@ ul, ol { list-style: none; }
 }
 
 .pubg-loader-content {
-  position: relative; z-index: 2;
-  display: flex; flex-direction: column; align-items: center;
+  /* Positioned above pseudo-elements and particles */
+  position: relative;
+  z-index: 10;
+
+  /* Own centering (belt + suspenders — loader already centers this) */
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   justify-content: center;
-  width: 100%; max-width: 500px;
-  padding: 0 20px;
-  animation: cinemaZoomIn 0.8s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
-  transform: scale(0.92);
+
+  /* Sizing */
+  width: 100%;
+  max-width: 520px;
+  padding: 0 24px;
+
+  /* Entrance animation */
+  animation: cinemaZoomIn 0.85s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+  transform: scale(0.9) translateY(12px);
   opacity: 0;
 }
 
 @keyframes cinemaZoomIn {
   0% {
-    transform: scale(0.92);
+    transform: scale(0.9) translateY(12px);
     opacity: 0;
   }
   100% {
-    transform: scale(1);
+    transform: scale(1) translateY(0);
     opacity: 1;
   }
 }


### PR DESCRIPTION
Fixes issue #1 - Loader not fullscreen and misaligned

Changes in style.css:
- .loader now uses explicit position:fixed; top:0; left:0; width:100%; height:100vh instead of shorthand inset:0, ensuring true fullscreen on all browsers
- Added flex-direction:column to .loader for correct vertical+horizontal centering
- Removed position:relative from .pubg-loader that was causing stacking context conflict
- Switched ::before / ::after pseudo-elements from position:fixed to position:absolute with width:100%; height:100%, fixing incorrect coverage inside fixed parent
- Raised .pubg-loader-content z-index from 2 to 10 (above particles and overlays)
- Improved entrance animation: scale + translateY rise-up for cinematic depth
- Exit animation now includes opacity fade + subtle scale(1.04) for premium feel
- Added body.loader-active { overflow:hidden } to prevent page scroll under loader
- Added clip-path:inset(0) to .loader as a guard against content overflow
- All absolute-positioned overlay divs now use width/height 100% instead of 100vw/vh

Changes in main.js:
- Added document.body.classList.add('loader-active') immediately at script start so scroll is blocked from the very first frame (not just after window.load)
- body.loader-active is removed after the 900ms exit transition fully completes
- triggerHeroEntrance() now fires only after loader is visually gone
- Extended dramatic pause at 100% to 400ms before fade begins
- Removed unused easeInOutCubic function; cleaned up unused maxDuration variable